### PR TITLE
BF - allow import without iris module

### DIFF
--- a/lib/eofs/tools/__init__.py
+++ b/lib/eofs/tools/__init__.py
@@ -34,4 +34,4 @@ try:
     from . import iris
     __all__.append('iris')
 except ImportError:
-    raise
+    pass


### PR DESCRIPTION
Changed from raising an error to ignoring an error when iris can't be imported.
