### PR TITLE
Ensure hidden table of contents is shown.

### DIFF
--- a/doc/_themes/sphinx13/layout.html
+++ b/doc/_themes/sphinx13/layout.html
@@ -78,5 +78,5 @@
 {# show the full table of contents in the sidebar #}
 {% block sidebartoc %}
     <h3>{{ _('Table of Contents') }}</h3>
-    {{ toctree() }}
+    {{ toctree(includehidden=True) }}
 {% endblock %}


### PR DESCRIPTION
A new feature in Sphinx 1.2b1 requires adding an argument to the toctree() template function in order to display hidden tables of contents.
