### PR TITLE
Modifications to use Conda for Travis CI testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,44 +1,43 @@
 language: python
 
 python:
-  - "2.7"
+    - "2.7"
 
 install:
-
-# Add a repository for up-to-dat geos/proj (from iris .travis.yml).
-  - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3E5C1192
-  - yes | sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable
-  - sudo apt-get update
-
-# Install dependencies. Whilst eofs requires only numpy, it is better to test the
-# cdms2 and iris compatibility also. Most of these dependencies are for those
-# packages rather than eofs itself.
-  - sudo apt-get install python-pip python-scipy cython
-  - sudo apt-get install libudunits2-dev libhdf5-serial-dev libnetcdf-dev netcdf-bin
-  - sudo apt-get install libgeos-dev libproj-dev
-  - sudo apt-get install python-matplotlib
-  - sudo /usr/bin/pip install --use-mirrors shapely nose pyshp pep8 mock
-  - sudo /usr/bin/pip install pyke netCDF4
-  - sudo /usr/bin/pip install cdat-lite
-  - sudo /usr/bin/pip install coverage
-  - mkdir ../prereqs
-  - cd ../prereqs
-  - wget http://python-distribute.org/distribute_setup.py
-  - sudo /usr/bin/python distribute_setup.py
-  - git clone git://github.com/SciTools/cartopy.git
-  - cd cartopy
-  - git checkout v0.8.0
-  - sudo /usr/bin/python setup.py install
-  - cd ..
-  - git clone git://github.com/SciTools/iris.git
-  - cd iris
-  - git checkout v1.4.0
-  - /usr/bin/python setup.py std_names
-  - sudo /usr/bin/python setup.py install
-  - cd ../../eofs
+    # Make sure system components are up to date:
+    - sudo apt-get update
+    # Install Miniconda so we can use it to manage dependencies:
+    - if [[ "$TRAVIS_PYTHON_VERSION" == 2* ]]; then
+        wget http://repo.continuum.io/miniconda/Miniconda-3.4.2-Linux-x86_64.sh -O miniconda.sh;
+      else
+        wget http://repo.continuum.io/miniconda/Miniconda3-3.4.2-Linux-x86_64.sh -O miniconda.sh;
+      fi
+    - bash miniconda.sh -b -p $HOME/miniconda
+    - export PATH="$HOME/miniconda/bin:$PATH"
+    - hash -r
+    - conda config --set always_yes yes --set changeps1 no
+    - conda config --add channels ajdawson
+    - conda update conda
+    - conda info -a
+    # Create a conda environment with the base dependencies:
+    - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION
+    - source activate test-environment
+    - conda install nose coverage numpy
+    # Additional dependencies for Python 2.x:
+    - if [[ "$TRAVIS_PYTHON_VERSION" == 2* ]]; then
+        conda config --add channels rsignell;
+        conda install cdat-lite iris;
+        export UDUNITS2_XML_PATH=/home/travis/miniconda/envs/test-environment/share/udunits/udunits2.xml;
+      fi
+    # Install the package:
+    - python setup.py install
 
 script:
-  - /usr/bin/python tests.py --verbosity=2 --with-coverage --cover-package=eofs
+    # Create an isolated test directory to make sure we test against the
+    # installed package rather than the source:
+    - mkdir ../test_directory
+    - cd ../test_directory
+    - nosetests eofs --verbosity=2 --with-coverage --cover-package=eofs
 
 notifications:
-  email: false
+    email: false

--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,11 @@ for line in open('lib/eofs/__init__.py').readlines():
 packages = ['eofs',
             'eofs.tools',
             'eofs.multivariate',
-            'eofs.examples',]
+            'eofs.examples',
+            'eofs.tests',]
 
-package_data = {'eofs.examples': ['example_data/*']}
+package_data = {'eofs.examples': ['example_data/*'],
+                'eofs.tests': ['data/*'],}
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
An update to the Travis CI configuration, which can now use Conda to install dependencies resulting is faster testing and easier to maintain Travis CI configuration.
