### PR TITLE
Use isinstance instead of directly checking type.

### DIFF
--- a/lib/eofs/iris.py
+++ b/lib/eofs/iris.py
@@ -100,7 +100,7 @@ class Eof(object):
 
         """
         # Check that the input is an Iris cube.
-        if type(cube) is not Cube:
+        if not isinstance(cube, Cube):
             raise TypeError('the input must be an iris cube')
         # Check for a time coordinate, raise an error if there isn't one.
         # The coord_and_dim function will raise a ValuerError with a
@@ -653,7 +653,7 @@ class Eof(object):
 
         """
         # Check that the input is an Iris cube.
-        if type(cube) is not Cube:
+        if not isinstance(cube, Cube):
             raise TypeError('the input must be an iris cube')
         cube_name = cube.name(default='dataset').replace(' ', '_')
         has_time = False

--- a/lib/eofs/multivariate/iris.py
+++ b/lib/eofs/multivariate/iris.py
@@ -123,7 +123,7 @@ class MultivariateEof(object):
         self._coords = []
         passweights = []
         for cube, weight in zip(cubes, weights):
-            if type(cube) is not Cube:
+            if not isinstance(cube, Cube):
                 raise TypeError('input is not an iris cube')
             # Record the time dimension and it's position. If its position is
             # not 0 then raise an error.
@@ -645,7 +645,7 @@ class MultivariateEof(object):
 
         """
         for cube in cubes:
-            if type(cube) is not Cube:
+            if not isinstance(cube, Cube):
                 raise TypeError('input is not an iris cube')
         if len(cubes) != self._ncubes:
             raise ValueError('number of cubes is incorrect, expecting {:d} '


### PR DESCRIPTION
Replace direct inspection of input type with use of `isinstance`.