### PR TITLE
Workaround for numpy regression.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,9 @@ install:
     # Additional dependencies for Python 2.x:
     - if [[ "$TRAVIS_PYTHON_VERSION" == 2* ]]; then
         conda config --add channels SciTools;
-        conda install setuptools nose coverage numpy=1.9 cdat-lite iris;
+        conda install setuptools nose coverage numpy cdat-lite iris;
       else
-        conda install setuptools nose coverage numpy=1.9;
+        conda install setuptools nose coverage numpy;
       fi
     # Install the package:
     - python setup.py install

--- a/lib/eofs/tools/standard.py
+++ b/lib/eofs/tools/standard.py
@@ -108,6 +108,7 @@ def correlation_map(pcs, field):
     div = np.float64(pcs_cent.shape[0])
     # Compute the correlation map.
     cor = ma.dot(field_cent.T, pcs_cent).T / div
+    cor = ma.masked_invalid(cor)
     cor /= ma.outer(pcs_std, field_std)
     # Return the correlation with the appropriate shape.
     return cor.reshape(out_shape)
@@ -160,4 +161,5 @@ def covariance_map(pcs, field, ddof=1):
     div = np.float64(pcs_cent.shape[0] - ddof)
     # Compute the covariance map, making sure it has the appropriate shape.
     cov = (ma.dot(field_cent.T, pcs_cent).T / div).reshape(out_shape)
+    cov = ma.masked_invalid(cov)
     return cov


### PR DESCRIPTION
Version 1.10 of numpy had a regression where ma.dot no longer always returned a masked array. This is fixed in numpy 1.10.2 but there are users on 1.10.0 and 1.10.1 who are having problems with eofs so a quick fix could be useful.