### PR TITLE
Backport numpy fix and CI improvements.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: python
 python:
     - "2.7"
     - "3.3"
+    - "3.4"
+    - "3.5"
 
 sudo: false
 
@@ -15,6 +17,7 @@ install:
       fi
     - bash miniconda.sh -b -p $HOME/miniconda
     - export PATH="$HOME/miniconda/bin:$PATH"
+    - hash -r
     - conda config --set always_yes yes --set changeps1 no
     - conda config --add channels ajdawson
     - conda update conda

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ python:
     - "2.7"
     - "3.3"
 
+sudo: false
+
 install:
-    # Make sure system components are up to date:
-    - sudo apt-get update
     # Install Miniconda so we can use it to manage dependencies:
     - if [[ "$TRAVIS_PYTHON_VERSION" == 2* ]]; then
         wget http://repo.continuum.io/miniconda/Miniconda-3.4.2-Linux-x86_64.sh -O miniconda.sh;
@@ -15,7 +15,6 @@ install:
       fi
     - bash miniconda.sh -b -p $HOME/miniconda
     - export PATH="$HOME/miniconda/bin:$PATH"
-    - hash -r
     - conda config --set always_yes yes --set changeps1 no
     - conda config --add channels ajdawson
     - conda update conda

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,12 @@ install:
     # Create a conda environment with the base dependencies:
     - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION
     - source activate test-environment
-    - conda install setuptools nose coverage numpy
     # Additional dependencies for Python 2.x:
     - if [[ "$TRAVIS_PYTHON_VERSION" == 2* ]]; then
-        conda config --add channels rsignell;
-        conda install cdat-lite iris;
-        export UDUNITS2_XML_PATH=/home/travis/miniconda/envs/test-environment/share/udunits/udunits2.xml;
+        conda config --add channels SciTools;
+        conda install setuptools nose coverage numpy cdat-lite iris;
+      else
+        conda install setuptools nose coverage numpy;
       fi
     # Install the package:
     - python setup.py install

--- a/lib/eofs/tools/standard.py
+++ b/lib/eofs/tools/standard.py
@@ -108,6 +108,7 @@ def correlation_map(pcs, field):
     div = np.float64(pcs_cent.shape[0])
     # Compute the correlation map.
     cor = ma.dot(field_cent.T, pcs_cent).T / div
+    cor = ma.masked_invalid(cor)
     cor /= ma.outer(pcs_std, field_std)
     # Return the correlation with the appropriate shape.
     return cor.reshape(out_shape)
@@ -160,4 +161,5 @@ def covariance_map(pcs, field, ddof=1):
     div = np.float64(pcs_cent.shape[0] - ddof)
     # Compute the covariance map, making sure it has the appropriate shape.
     cov = (ma.dot(field_cent.T, pcs_cent).T / div).reshape(out_shape)
+    cov = ma.masked_invalid(cov)
     return cov


### PR DESCRIPTION
The goal of this PR is to be able to provide a v0.5.1 release to avoid rushing v1.0. This branch has two cherry-picked commits from master:

* workaround for a bug in numpy 1.10
* enable containerised builds on travis

It also has a new commit which enables Python 3.4 and 3.5 testing (not worth a cherry-pick).