### PR TITLE
Improve the build matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,19 @@ python:
 
 sudo: false
 
+env:
+    - TEST_MODE=complete
+    - TEST_MODE=basic
+
+matrix:
+    exclude:
+        - python: "3.3"
+          env: TEST_MODE=complete
+        - python: "3.4"
+          env: TEST_MODE=complete
+        - python: "3.5"
+          env: TEST_MODE=complete
+
 install:
     # Install Miniconda so we can use it to manage dependencies:
     - if [[ "$TRAVIS_PYTHON_VERSION" == 2* ]]; then
@@ -26,7 +39,7 @@ install:
     - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION
     - source activate test-environment
     # Additional dependencies for Python 2.x:
-    - if [[ "$TRAVIS_PYTHON_VERSION" == 2* ]]; then
+    - if [[ "$TRAVIS_PYTHON_VERSION" == 2* ]] && [[ "$TEST_MODE" == "complete" ]]; then
         conda config --add channels SciTools;
         conda install setuptools nose coverage numpy cdat-lite iris;
       else


### PR DESCRIPTION
This allows a build to be tested in both basic mode (without metadata interfaces) as well as complete mode (with metadata interfaces). The metadata interfaces impose other constraints on the environment (numpy version in particular) that we don't always want. This should avoid bugs like #34 being so surprising, as the basic test mode should always use the latest numpy.

Conda packages for Iris on Python 3.4 are anticipated in the near future, at which point the exclude for 3.4 can be removed.