### PR TITLE
Add description of EOFs to readme. Closes #23.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ eofs - EOF analysis in Python
 Overview
 --------
 
-eofs is a Python package for performing EOF analysis on spatial-temporal data sets, licensed under the GNU GPLv3.
+eofs is a Python package for performing empirical orthogonal function (EOF) analysis on spatial-temporal data sets, licensed under the GNU GPLv3.
 
 The package was created to simplify the process of EOF analysis in the Python environment.
 Some of the key features are listed below:


### PR DESCRIPTION
Adds the full name of the analysis method in the first line of the README, lacking the description has been suggested as confusing (see #23).