### PR TITLE
Advance development version to 1.2.

### DIFF
--- a/lib/eofs/__init__.py
+++ b/lib/eofs/__init__.py
@@ -25,7 +25,7 @@ from . import tools
 __all__ = ['standard', 'tools']
 
 # Package version number.
-__version__ = '1.1.x'
+__version__ = '1.2.dev0'
 
 try:
     from . import cdms


### PR DESCRIPTION
A release branch for v1.1.x has been cut, bump the development version by a minor increment.