### PR TITLE
Update testing documentation for v1.1.x.

### DIFF
--- a/doc/devguide/testing.rst
+++ b/doc/devguide/testing.rst
@@ -7,7 +7,7 @@ Testing against the source tree is handy during development when quick iteration
 
 Running the test suite requires nose_ and pep8_ to be installed.
 The test suite will function as long as the minimum dependencies for the package are installed, but some tests will be skipped if they require optional dependencies that are not present.
-To run the full test suite you need to have the optional dependencies `cdms2` (from UV-CDAT_) and iris_ installed.
+To run the full test suite you need to have the optional dependencies `cdms2` (from UV-CDAT_), iris_, and xarray_ installed.
 
 Testing against the current source tree
 ---------------------------------------
@@ -17,10 +17,6 @@ Testing the current source is straightforward, from the source directory run::
     nosetests -sv
 
 This will perform verbose testing of the current source tree and print a summary at the end.
-
-.. note::
-
-   Support for Python 3 in `eofs` is implemented via ``2to3`` which converts the source code to be compatible with Python 3 at *build* time. This means that testing against the source tree for Python 3 is not advised or supported at the current time.
 
 
 Testing an installed version
@@ -45,3 +41,5 @@ This will run the tests on the version of `eofs` you just installed.
 .. _UV-CDAT: http://uv-cdat.llnl.gov
 
 .. _iris: http://scitools.org.uk/iris
+
+.. _xarray: http://xarray.pydata.org


### PR DESCRIPTION
This release is Python 3 compatible (you can run tests against the source) and the full test suite requires xarray in addition to cdms2 and iris.