### PR TITLE
Better identification of time coordinates.

### DIFF
--- a/lib/eofs/iris.py
+++ b/lib/eofs/iris.py
@@ -24,7 +24,7 @@ from iris.cube import Cube
 from iris.coords import DimCoord
 
 from . import standard
-from .tools.iris import coord_and_dim, weights_array, classified_aux_coords
+from .tools.iris import get_time_coord, weights_array, classified_aux_coords
 
 
 class Eof(object):
@@ -104,9 +104,9 @@ class Eof(object):
         if not isinstance(cube, Cube):
             raise TypeError('the input must be an iris cube')
         # Check for a time coordinate, raise an error if there isn't one.
-        # The coord_and_dim function will raise a ValuerError with a
+        # The get_time_coord function will raise a ValuerError with a
         # useful message so no need to handle it explicitly here.
-        _time, self._time_dim = coord_and_dim(cube, 'time')
+        _time, self._time_dim = get_time_coord(cube)
         self._time = copy(_time)
         if self._time_dim != 0:
             raise ValueError('time must be the first dimension, '
@@ -656,7 +656,7 @@ class Eof(object):
         has_time = False
         try:
             # A time dimension must be first.
-            time, time_dim = coord_and_dim(cube, 'time')
+            time, time_dim = get_time_coord(cube)
             has_time = True
         except ValueError:
             # No time dimension is also acceptable.

--- a/lib/eofs/multivariate/iris.py
+++ b/lib/eofs/multivariate/iris.py
@@ -23,7 +23,7 @@ from copy import copy
 from iris.cube import Cube
 from iris.coords import DimCoord
 
-from eofs.tools.iris import (coord_and_dim, weights_array,
+from eofs.tools.iris import (get_time_coord, weights_array,
                              classified_aux_coords, common_items)
 from . import standard
 
@@ -128,7 +128,7 @@ class MultivariateEof(object):
                 raise TypeError('input is not an iris cube')
             # Record the time dimension and it's position. If its position is
             # not 0 then raise an error.
-            time, time_dim = coord_and_dim(cube, 'time')
+            time, time_dim = get_time_coord(cube)
             if time_dim != 0:
                 raise ValueError('time must be the first dimension, '
                                  'consider using the transpose() method')
@@ -686,7 +686,7 @@ class MultivariateEof(object):
             try:
                 # Time dimension must be first.
                 raise_error = False
-                time, time_coord = coord_and_dim(cube, 'time')
+                time, time_coord = get_time_coord(cube)
                 if time_coord != 0:
                     raise_error = True
             except ValueError:
@@ -713,7 +713,7 @@ class MultivariateEof(object):
             pcdim = DimCoord(list(range(pcs.shape[1])),
                              var_name='pc',
                              long_name='pc_number')
-            time, time_dim = coord_and_dim(cubes[0], 'time')
+            time, time_dim = get_time_coord(cubes[0])
             pcs.add_dim_coord(copy(time), 0)
             pcs.add_dim_coord(pcdim, 1)
             # Add any auxiliary coordinates for the time dimension.

--- a/lib/eofs/tests/test_error_handling.py
+++ b/lib/eofs/tests/test_error_handling.py
@@ -396,6 +396,7 @@ class TestConstructorIris(EofsTest):
         data = solution['sst']
         lon = data.coord('longitude')
         lon.rename('time')
+        lon.units = 'days since 1999-01-01 00:00:0.0'
         solver = self.solver_class(data)
 
 


### PR DESCRIPTION
Changes the way time coordinates are identified in the iris interface. Previously the name had to include the string `'time'`, but this is changed to use the iris built-in checks for time units on a coordinate. If no time coordinates are found using this method we fall back to the previous method, so the change should be backwards compatible. See #68 for background.