### PR TITLE
Update for deprecations in dependencies

### DIFF
--- a/lib/eofs/cdms.py
+++ b/lib/eofs/cdms.py
@@ -128,7 +128,7 @@ class Eof(object):
         # are several weighting schemes. The 'area' weighting scheme requires
         # a latitude-longitude grid to be present, the 'cos_lat' scheme only
         # requires a latitude dimension.
-        if weights in ('none', None):
+        if weights is None or weights == 'none':
             # No weights requested, set the weight array to None.
             wtarray = None
         else:

--- a/lib/eofs/tests/reference.py
+++ b/lib/eofs/tests/reference.py
@@ -126,7 +126,7 @@ def _wrap_iris(solution, neofs, time_units):
     try:
         from iris.cube import Cube
         from iris.coords import DimCoord
-        from iris.unit import Unit
+        from cf_units import Unit
     except ImportError:
         raise ValueError("cannot use container 'iris' without "
                          "the iris module")

--- a/lib/eofs/tests/utils.py
+++ b/lib/eofs/tests/utils.py
@@ -86,10 +86,11 @@ def sign_adjustments(eofset, refeofset):
     eofset, refeofset = __tomasked(eofset, refeofset)
     nmodes = eofset.shape[0]
     signs = np.ones([nmodes])
-    shape = np.ones(eofset.ndim)
-    shape[0] = nmodes
-    eofset = eofset.reshape([nmodes, np.prod(eofset.shape[1:])])
-    refeofset = refeofset.reshape([nmodes, np.prod(refeofset.shape[1:])])
+    shape = [nmodes] + [1] * (eofset.ndim - 1)
+    eofset = eofset.reshape([nmodes, np.prod(eofset.shape[1:], dtype=np.int)])
+    refeofset = refeofset.reshape([nmodes,
+                                   np.prod(refeofset.shape[1:],
+                                           dtype=np.int)])
     for mode in range(nmodes):
         i = 0
         try:


### PR DESCRIPTION
Update code to eliminate deprecation warnings from our dependencies when running the test suite. Only one change is in the library code, which ensures the cdms interface will work on later versions of numpy (although cdms2 itself currently does not support versions > 1.9).