### PR TITLE
Use latest version in Zenodo DOI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 eofs - EOF analysis in Python
 =============================
 
-[![Build Status](https://api.travis-ci.org/repositories/ajdawson/eofs.svg?branch=master)](https://travis-ci.org/ajdawson.eofs) [![DOI (paper)](https://img.shields.io/badge/DOI%20%28paper%29-10.5334%2Fjors.122-blue.svg)](http://doi.org/10.5334/jors.122) [![DOI (zenodo)](https://zenodo.org/badge/doi/10.5281/zenodo.46871.svg)](http://dx.doi.org/10.5281/zenodo.46871)
+[![Build Status](https://api.travis-ci.org/repositories/ajdawson/eofs.svg?branch=master)](https://travis-ci.org/ajdawson.eofs) [![DOI (paper)](https://img.shields.io/badge/DOI%20%28paper%29-10.5334%2Fjors.122-blue.svg)](http://doi.org/10.5334/jors.122) [![DOI (latest release)](https://zenodo.org/badge/20448/ajdawson/eofs.svg)](https://zenodo.org/badge/latestdoi/20448/ajdawson/eofs)
 
 
 Overview


### PR DESCRIPTION
Use the generic latest release DOI from Zenodo, this ensures the badge in the README will refer to the latest version.