### PR TITLE
Instruct users to install from conda-forge channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Installation
 eofs works on Python 2 or 3 on Linux, Windows or OSX.
 The easiest way to install eofs is by using [conda](http://conda.pydata.org/docs/) or pip:
 
-    conda install -c ajdawson eofs
+    conda install -c conda-forge eofs
 
 or
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -32,7 +32,7 @@ The :ref:`cdms <cdms-interface>`, :ref:`iris <iris-interface>`, and :ref:`xarray
 
 `eofs` can be installed for all platforms using conda_::
 
-    conda install -c ajdawson eofs
+    conda install -c conda-forge eofs
 
 or using pip::
 


### PR DESCRIPTION
Use the `conda-forge` channel instead of `ajdawson`.