### PR TITLE
Use data component of cdms2 variables for plotting

### DIFF
--- a/examples/cdms/hgt_example.py
+++ b/examples/cdms/hgt_example.py
@@ -50,7 +50,7 @@ proj = ccrs.Orthographic(central_longitude=-20, central_latitude=60)
 ax = plt.axes(projection=proj)
 ax.set_global()
 ax.coastlines()
-ax.contourf(lons, lats, eof1(squeeze=True), levels=clevs,
+ax.contourf(lons, lats, eof1(squeeze=True).data, levels=clevs,
             cmap=plt.cm.RdBu_r, transform=ccrs.PlateCarree())
 plt.title('EOF1 expressed as covariance', fontsize=16)
 

--- a/examples/cdms/sst_example.py
+++ b/examples/cdms/sst_example.py
@@ -46,7 +46,7 @@ pc1 = solver.pcs(npcs=1, pcscaling=1)
 lons, lats = eof1.getLongitude()[:], eof1.getLatitude()[:]
 clevs = np.linspace(-1, 1, 11)
 ax = plt.axes(projection=ccrs.PlateCarree(central_longitude=190))
-fill = ax.contourf(lons, lats, eof1(squeeze=True), clevs,
+fill = ax.contourf(lons, lats, eof1(squeeze=True).data, clevs,
                    transform=ccrs.PlateCarree(), cmap=plt.cm.RdBu_r)
 ax.add_feature(cfeature.LAND, facecolor='w', edgecolor='k')
 cb = plt.colorbar(fill, orientation='horizontal')
@@ -56,7 +56,7 @@ plt.title('EOF1 expressed as correlation', fontsize=16)
 # Plot the leading PC time series.
 plt.figure()
 years = range(1962, 2012)
-plt.plot(years, pc1, color='b', linewidth=2)
+plt.plot(years, pc1.data, color='b', linewidth=2)
 plt.axhline(0, color='k')
 plt.title('PC1 Time Series')
 plt.xlabel('Year')


### PR DESCRIPTION
Passing a cdms2 variable to matplotlib works for some cases but not others and is dependent on cdms2 version. The safest thing to do is pass the array contained by the variable instead.