### PR TITLE
Fixes and updates for Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ env:
         - NAME="Python 2.7 (metadata)"
           PYTHON_VERSION=2.7
           PACKAGES="${PACKAGES_STANDARD} cdat-lite iris xarray"
-        - NAME="Python 3.3 (standard)"
-          PYTHON_VERSION=3.3
-          PACKAGES="${PACKAGES_STANDARD}"
         - NAME="Python 3.4 (standard)"
           PYTHON_VERSION=3.4
           PACKAGES="${PACKAGES_STANDARD}"
@@ -26,7 +23,13 @@ env:
           PACKAGES="${PACKAGES_STANDARD}"
         - NAME="Python 3.5 (metadata)"
           PYTHON_VERSION=3.5
-          PACKAGES="${PACKAGES_STANDARD} xarray"
+          PACKAGES="${PACKAGES_STANDARD} iris xarray"
+        - NAME="Python 3.6 (standard)"
+          PYTHON_VERSION=3.6
+          PACKAGES="${PACKAGES_STANDARD}"
+        - NAME="Python 3.6 (metadata)"
+          PYTHON_VERSION=3.6
+          PACKAGES="${PACKAGES_STANDARD} iris xarray"
 
 install:
     # Install Miniconda so we can use it to manage dependencies:
@@ -40,8 +43,7 @@ install:
     - hash -r
     # Setup conda to use extra channels for dependencies:
     - conda config --set always_yes yes --set changeps1 no
-    - conda config --add channels scitools
-    - conda config --add channels ajdawson
+    - conda config --add channels conda-forge
     - conda update conda
     - conda info -a
     # Create a conda environment with the required python version:

--- a/lib/eofs/__init__.py
+++ b/lib/eofs/__init__.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with eofs.  If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import
+from __future__ import (absolute_import, division, print_function)  # noqa
 
 from . import standard
 from . import tools

--- a/lib/eofs/cdms.py
+++ b/lib/eofs/cdms.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with eofs.  If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import
+from __future__ import (absolute_import, division, print_function)  # noqa
 
 import collections
 

--- a/lib/eofs/examples/__init__.py
+++ b/lib/eofs/examples/__init__.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with eofs.  If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import
+from __future__ import (absolute_import, division, print_function)  # noqa
 import os
 
 

--- a/lib/eofs/iris.py
+++ b/lib/eofs/iris.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with eofs.  If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import
+from __future__ import (absolute_import, division, print_function)  # noqa
 
 import collections
 from copy import copy

--- a/lib/eofs/multivariate/__init__.py
+++ b/lib/eofs/multivariate/__init__.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with eofs.  If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import
+from __future__ import (absolute_import, division, print_function)  # noqa
 
 from . import standard
 

--- a/lib/eofs/multivariate/cdms.py
+++ b/lib/eofs/multivariate/cdms.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with eofs.  If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import
+from __future__ import (absolute_import, division, print_function)  # noqa
 
 import collections
 

--- a/lib/eofs/multivariate/iris.py
+++ b/lib/eofs/multivariate/iris.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with eofs.  If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import
+from __future__ import (absolute_import, division, print_function)  # noqa
 
 import collections
 from copy import copy

--- a/lib/eofs/multivariate/standard.py
+++ b/lib/eofs/multivariate/standard.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with eofs.  If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import
+from __future__ import (absolute_import, division, print_function)  # noqa
 
 import numpy as np
 

--- a/lib/eofs/standard.py
+++ b/lib/eofs/standard.py
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with eofs.  If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import
+from __future__ import (absolute_import, division, print_function)  # noqa
 import collections
 import warnings
 

--- a/lib/eofs/tests/__init__.py
+++ b/lib/eofs/tests/__init__.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with eofs.  If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import
+from __future__ import (absolute_import, division, print_function)  # noqa
 
 from nose.tools import assert_almost_equal, assert_true, assert_equal
 import numpy as np

--- a/lib/eofs/tests/test_error_handling.py
+++ b/lib/eofs/tests/test_error_handling.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with eofs.  If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import
+from __future__ import (absolute_import, division, print_function)  # noqa
 
 from nose import SkipTest
 from nose.tools import raises

--- a/lib/eofs/tests/test_multivariate_error_handling.py
+++ b/lib/eofs/tests/test_multivariate_error_handling.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with eofs.  If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import
+from __future__ import (absolute_import, division, print_function)  # noqa
 
 from nose import SkipTest
 from nose.tools import raises

--- a/lib/eofs/tests/test_multivariate_solution.py
+++ b/lib/eofs/tests/test_multivariate_solution.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with eofs.  If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import
+from __future__ import (absolute_import, division, print_function)  # noqa
 
 from nose import SkipTest
 import numpy as np

--- a/lib/eofs/tests/test_solution.py
+++ b/lib/eofs/tests/test_solution.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with eofs.  If not, see <http://www.gnu.org/licenses/>.
-from __future__ import (absolute_import, division, print_function)
+from __future__ import (absolute_import, division, print_function)  # noqa
 
 from nose import SkipTest
 import numpy as np

--- a/lib/eofs/tests/test_solution.py
+++ b/lib/eofs/tests/test_solution.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with eofs.  If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import
+from __future__ import (absolute_import, division, print_function)
 
 from nose import SkipTest
 import numpy as np
@@ -112,7 +112,7 @@ class SolutionTest(EofsTest):
         eofs = self._tomasked(self.solver.eofs(neofs=self.neofs,
                                                eofscaling=eofscaling))
         eofs = eofs.compressed()
-        ns = eofs.shape[0] / self.neofs
+        ns = eofs.shape[0] // self.neofs
         eofs = eofs.reshape([self.neofs, ns])
         dot = np.dot(eofs, eofs.T)
         residual = dot - np.diag(dot.diagonal())

--- a/lib/eofs/tests/test_tools.py
+++ b/lib/eofs/tests/test_tools.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with eofs.  If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import
+from __future__ import (absolute_import, division, print_function)  # noqa
 
 from nose import SkipTest
 from nose.tools import raises

--- a/lib/eofs/tests/utils.py
+++ b/lib/eofs/tests/utils.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with eofs.  If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import
+from __future__ import (absolute_import, division, print_function)  # noqa
 
 import numpy as np
 try:

--- a/lib/eofs/tools/__init__.py
+++ b/lib/eofs/tools/__init__.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with eofs.  If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import
+from __future__ import (absolute_import, division, print_function)  # noqa
 
 from . import standard
 

--- a/lib/eofs/tools/cdms.py
+++ b/lib/eofs/tools/cdms.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with eofs.  If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import
+from __future__ import (absolute_import, division, print_function)  # noqa
 
 import cdms2
 import numpy as np

--- a/lib/eofs/tools/generic.py
+++ b/lib/eofs/tools/generic.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with eofs.  If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import
+from __future__ import (absolute_import, division, print_function)  # noqa
 
 
 def covcor_dimensions(pc_dims, field_dims):

--- a/lib/eofs/tools/iris.py
+++ b/lib/eofs/tools/iris.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with eofs.  If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import
+from __future__ import (absolute_import, division, print_function)  # noqa
 from copy import copy
 from functools import reduce
 import warnings

--- a/lib/eofs/tools/standard.py
+++ b/lib/eofs/tools/standard.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with eofs.  If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import
+from __future__ import (absolute_import, division, print_function)  # noqa
 
 import numpy as np
 import numpy.ma as ma

--- a/lib/eofs/tools/xarray.py
+++ b/lib/eofs/tools/xarray.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with eofs.  If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import
+from __future__ import (absolute_import, division, print_function)  # noqa
 
 import numpy as np
 try:

--- a/lib/eofs/xarray.py
+++ b/lib/eofs/xarray.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with eofs.  If not, see <http://www.gnu.org/licenses/>.
-from __future__ import absolute_import
+from __future__ import (absolute_import, division, print_function)  # noqa
 
 import collections
 


### PR DESCRIPTION
Fixes an issue where floating point divide was being used instead of integer divide. Also ensures all modules import `division` from `__future__` so that behaviour is consistent on Python 2 and 3. The CI matrix has been updated to drop Python 3.3 and add Python 3.6, also including Iris for metadata interface tests on Python 3.5 and 3.6 now.