### PR TITLE
Modernize the testing components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ dist
 *.tmp*
 .coverage
 MANIFEST
+.cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 
 env:
     global:
-        - PACKAGES_STANDARD="setuptools numpy nose pep8 coverage"
+        - PACKAGES_STANDARD="setuptools numpy pytest pycodestyle"
     matrix:
         - NAME="Python 2.7 (standard)"
           PYTHON_VERSION=2.7
@@ -59,7 +59,7 @@ script:
     # installed package rather than the source:
     - mkdir ../test_directory
     - cd ../test_directory
-    - nosetests eofs --verbosity=2 --with-coverage --cover-package=eofs
+    - pytest -vrsx --pyargs eofs
 
 notifications:
     email: false

--- a/doc/devguide/testing.rst
+++ b/doc/devguide/testing.rst
@@ -5,7 +5,7 @@ The package comes with a comprehensive set of tests to make sure it is working c
 The tests can be run against an installed version of `eofs` or against the current source tree.
 Testing against the source tree is handy during development when quick iteration is required, but for most other cases testing against the installed version is more suitable.
 
-Running the test suite requires nose_ and pep8_ to be installed.
+Running the test suite requires pytest_ and pycodestyle_ to be installed.
 The test suite will function as long as the minimum dependencies for the package are installed, but some tests will be skipped if they require optional dependencies that are not present.
 To run the full test suite you need to have the optional dependencies `cdms2` (from UV-CDAT_), iris_, and xarray_ installed.
 
@@ -14,7 +14,7 @@ Testing against the current source tree
 
 Testing the current source is straightforward, from the source directory run::
 
-    nosetests -sv
+    pytest
 
 This will perform verbose testing of the current source tree and print a summary at the end.
 
@@ -27,16 +27,16 @@ First you need to install `eofs` into your current Python environment::
     cd eofs/
     python setup.py install
 
-Then create a directory somewhere else without any Python code in it and run ``nosetests`` from there giving the package name ``eofs`` as a positional argument::
+Then create a directory somewhere else without any Python code in it and run ``pytest`` from there::
 
     mkdir $HOME/eofs-test-dir && cd $HOME/eofs-test-dir
-    nosetests -sv eofs
+    pytest --pyargs eofs
 
 This will run the tests on the version of `eofs` you just installed.
 
-.. _nose: https://nose.readthedocs.org/en/latest/
+.. _pytest: https://docs.pytest.org/en/latest/
 
-.. _pep8: https://pypi.python.org/pypi/pep8
+.. _pycodestyle: https://pypi.python.org/pypi/pycodestyle
 
 .. _UV-CDAT: http://uv-cdat.llnl.gov
 

--- a/lib/eofs/tests/__init__.py
+++ b/lib/eofs/tests/__init__.py
@@ -17,9 +17,8 @@
 # along with eofs.  If not, see <http://www.gnu.org/licenses/>.
 from __future__ import (absolute_import, division, print_function)  # noqa
 
-from nose.tools import assert_almost_equal, assert_true, assert_equal
 import numpy as np
-from numpy.testing.utils import assert_array_almost_equal
+import numpy.ma as ma
 
 
 np.seterr(all='ignore')
@@ -51,15 +50,18 @@ class EofsTest(object):
         comparison is made.
 
         """
-        assert_array_almost_equal(self._tomasked(a), self._tomasked(b))
+        assert ma.allclose(self._tomasked(a), self._tomasked(b))
 
     def assert_almost_equal(self, a, b):
         """Assertion that two values compare almost equal."""
-        assert_almost_equal(self._tomasked(a), self._tomasked(b))
+        assert ma.allclose(self._tomasked(a), self._tomasked(b))
 
     def assert_true(self, cond):
         """Assertion that a condition is True."""
-        assert_true(cond)
+        assert cond
 
     def assert_equal(self, a, b, message=None):
-        assert_equal(a, b, message)
+        if message is not None:
+            assert a == b, message
+        else:
+            assert a == b

--- a/lib/eofs/tests/test_coding_standards.py
+++ b/lib/eofs/tests/test_coding_standards.py
@@ -18,7 +18,7 @@
 
 import os
 
-import pep8
+import pycodestyle
 
 import eofs
 from eofs.tests import EofsTest
@@ -27,7 +27,7 @@ from eofs.tests import EofsTest
 class TestCodingStandards(EofsTest):
 
     def test_pep8(self):
-        pep8style = pep8.StyleGuide(quiet=False)
+        pep8style = pycodestyle.StyleGuide(quiet=False)
         base_paths = [os.path.dirname(eofs.__file__)]
         result = pep8style.check_files(base_paths)
         self.assert_equal(result.total_errors, 0, "Found PEP8 style issues.")

--- a/lib/eofs/tests/test_error_handling.py
+++ b/lib/eofs/tests/test_error_handling.py
@@ -17,13 +17,12 @@
 # along with eofs.  If not, see <http://www.gnu.org/licenses/>.
 from __future__ import (absolute_import, division, print_function)  # noqa
 
-from nose import SkipTest
-from nose.tools import raises
 import numpy as np
 try:
     import cdms2
 except ImportError:
     pass
+import pytest
 
 import eofs
 from eofs.tests import EofsTest
@@ -56,46 +55,46 @@ class ErrorHandlersTest(EofsTest):
         try:
             cls.solution = reference_solution(cls.interface, cls.weights)
         except ValueError:
-            raise SkipTest('library component not available '
-                           'for {!s} interface'.format(cls.interface))
+            pytest.skip('missing dependencies required to test '
+                        'the {!s} interface'.format(cls.interface))
         cls.neofs = cls.solution['eigenvalues'].shape[0]
         try:
             cls.solver = solvers[cls.interface](
                 cls.solution['sst'], weights=cls.solution['weights'])
         except KeyError:
-            raise SkipTest('library component not available '
-                           'for {!s} interface'.format(cls.interface))
+            pytest.skip('missing dependencies required to test '
+                        'the {!s} interface'.format(cls.interface))
 
-    @raises(ValueError)
     def test_invalid_pcscaling(self):
         # PCs with invalid scaling
-        pcs = self.solver.pcs(pcscaling=-1)
+        with pytest.raises(ValueError):
+            pcs = self.solver.pcs(pcscaling=-1)
 
-    @raises(ValueError)
     def test_invalid_eofscaling(self):
         # EOFs with invalid scaling
-        eofs = self.solver.eofs(eofscaling=-1)
+        with pytest.raises(ValueError):
+            eofs = self.solver.eofs(eofscaling=-1)
 
-    @raises(ValueError)
     def test_projectField_invalid_dimensions(self):
         # projecting a field with too few dimensions
         data = self.solution['sst'][:, 0, 0]
-        pcs = self.solver.projectField(data)
+        with pytest.raises(ValueError):
+            pcs = self.solver.projectField(data)
 
-    @raises(ValueError)
     def test_projectField_invalid_shape(self):
         # projecting a field with the wrong shape
         data = self.solution['sst'][..., 0:1]
-        pcs = self.solver.projectField(data)
+        with pytest.raises(ValueError):
+            pcs = self.solver.projectField(data)
 
-    @raises(ValueError)
     def test_projectField_different_missing_values(self):
         # projecting a field with different missing values
         solution = reference_solution(self.interface, self.weights)
         data = solution['sst']
         mask = data.mask
         mask[0] = True
-        pcs = self.solver.projectField(data)
+        with pytest.raises(ValueError):
+            pcs = self.solver.projectField(data)
 
 
 # ----------------------------------------------------------------------------
@@ -116,11 +115,11 @@ class TestErrorHandlersCDMS(ErrorHandlersTest):
     interface = 'cdms'
     weights = 'equal'
 
-    @raises(TypeError)
     def test_projectField_invalid_type(self):
         # projecting a field of the wrong type
         solution = reference_solution('standard', 'equal')
-        pcs = self.solver.projectField(solution['sst'])
+        with pytest.raises(TypeError):
+            pcs = self.solver.projectField(solution['sst'])
 
 
 # ----------------------------------------------------------------------------
@@ -132,28 +131,28 @@ class TestErrorHandlersIris(ErrorHandlersTest):
     interface = 'iris'
     weights = 'equal'
 
-    @raises(TypeError)
     def test_projectField_invalid_type(self):
         # projecting a field of the wrong type
         solution = reference_solution('standard', 'equal')
-        pcs = self.solver.projectField(solution['sst'])
+        with pytest.raises(TypeError):
+            pcs = self.solver.projectField(solution['sst'])
 
-    @raises(ValueError)
     def test_projectField_different_missing_values(self):
         # projecting a field with different missing values
         solution = reference_solution(self.interface, self.weights)
         data = solution['sst']
         mask = data.data.mask
         mask[0] = True
-        pcs = self.solver.projectField(data)
+        with pytest.raises(ValueError):
+            pcs = self.solver.projectField(data)
 
-    @raises(ValueError)
     def test_projectField_invalid_dimension_order(self):
         # projecting a field with the time dimension not at the front
         solution = reference_solution(self.interface, self.weights)
         data = solution['sst']
         data.transpose((2, 1, 0))
-        pcs = self.solver.projectField(data)
+        with pytest.raises(ValueError):
+            pcs = self.solver.projectField(data)
 
 
 # ----------------------------------------------------------------------------
@@ -165,27 +164,27 @@ class TestErrorHandlersXarray(ErrorHandlersTest):
     interface = 'xarray'
     weights = 'equal'
 
-    @raises(TypeError)
     def test_projectField_invalid_type(self):
         # projecting a field of the wrong type
         solution = reference_solution('standard', 'equal')
-        pcs = self.solver.projectField(solution['sst'])
+        with pytest.raises(TypeError):
+            pcs = self.solver.projectField(solution['sst'])
 
-    @raises(ValueError)
     def test_projectField_different_missing_values(self):
         # projecting a field with different missing values
         solution = reference_solution(self.interface, self.weights)
         data = solution['sst']
         data.values[0] = np.nan
-        pcs = self.solver.projectField(data)
+        with pytest.raises(ValueError):
+            pcs = self.solver.projectField(data)
 
-    @raises(ValueError)
     def test_projectField_invalid_dimension_order(self):
         # projecting a field with the time dimension not at the front
         solution = reference_solution(self.interface, self.weights)
         data = solution['sst']
-        data.transpose((2, 1, 0))
-        pcs = self.solver.projectField(data)
+        data = data.transpose('longitude', 'latitude', 'time')
+        with pytest.raises(ValueError):
+            pcs = self.solver.projectField(data)
 
 
 # ----------------------------------------------------------------------------
@@ -199,30 +198,29 @@ class TestConstructorStandard(EofsTest):
     def setup_class(cls):
         cls.solver_class = solvers['standard']
 
-    @raises(ValueError)
     def test_invalid_input_dimensions(self):
         # too few input dimensions
         solution = reference_solution('standard', 'equal')
         data = solution['sst'][:, 0, 0]
-        solver = self.solver_class(data)
+        with pytest.raises(ValueError):
+            solver = self.solver_class(data)
 
-    @raises(ValueError)
     def test_invalid_weights_dimensions(self):
         # weights with incompatible dimensions
         solution = reference_solution('standard', 'area')
         data = solution['sst']
         weights = solution['weights'][:, 0]
-        solver = self.solver_class(data, weights=weights)
+        with pytest.raises(ValueError):
+            solver = self.solver_class(data, weights=weights)
 
-    @raises(TypeError)
     def test_invalid_weights_type(self):
         # weights with an incompatible type
         solution = reference_solution('standard', 'area')
         data = solution['sst']
         weights = 'area'
-        solver = self.solver_class(data, weights=weights)
+        with pytest.raises(TypeError):
+            solver = self.solver_class(data, weights=weights)
 
-    @raises(ValueError)
     def test_input_with_all_missing_values(self):
         # input with only missing values, missing values are propagated
         # because the default for the center argument is True
@@ -230,9 +228,9 @@ class TestConstructorStandard(EofsTest):
         data = solution['sst']
         mask = data.mask
         mask[-1] = True
-        solver = self.solver_class(data)
+        with pytest.raises(ValueError):
+            solver = self.solver_class(data)
 
-    @raises(ValueError)
     def test_input_with_non_uniform_missing_values(self):
         # missing values in different places at different times leads to
         # errors in computing the SVD
@@ -240,7 +238,8 @@ class TestConstructorStandard(EofsTest):
         data = solution['sst']
         mask = data.mask
         mask[-1] = True
-        solver = self.solver_class(data, center=False)
+        with pytest.raises(ValueError):
+            solver = self.solver_class(data, center=False)
 
 
 # ----------------------------------------------------------------------------
@@ -255,60 +254,59 @@ class TestConstructorCDMS(EofsTest):
         try:
             cls.solver_class = solvers['cdms']
         except KeyError:
-            raise SkipTest('library component not available '
-                           'for cdms interface')
+            pytest.skip('missing dependencies required to test the '
+                        'cdms interface')
 
-    @raises(TypeError)
     def test_wrong_input_type(self):
         # input of the wrong type
         solution = reference_solution('standard', 'equal')
         data = solution['sst']
-        solver = self.solver_class(data)
+        with pytest.raises(TypeError):
+            solver = self.solver_class(data)
 
-    @raises(ValueError)
     def test_input_without_time_dimension(self):
         # no time dimension in the input
         solution = reference_solution('cdms', 'equal')
         data = solution['sst'](time=slice(0, 1), squeeze=True)
-        solver = self.solver_class(data)
+        with pytest.raises(ValueError):
+            solver = self.solver_class(data)
 
-    @raises(ValueError)
     def test_input_time_dimension_not_first(self):
         # time not the first dimension in the input
         solution = reference_solution('cdms', 'equal')
         data = solution['sst']
         data = data.reorder('xyt')
-        solver = self.solver_class(data)
+        with pytest.raises(ValueError):
+            solver = self.solver_class(data)
 
-    @raises(ValueError)
     def test_input_no_spatial_dimensions(self):
         # not enough dimensions in the input
         solution = reference_solution('cdms', 'equal')
         data = solution['sst'][:, 0, 0]
-        solver = self.solver_class(data)
+        with pytest.raises(ValueError):
+            solver = self.solver_class(data)
 
-    @raises(ValueError)
     def test_invalid_builtin_weights_value(self):
         # invalid weighting scheme name
         solution = reference_solution('cdms', 'equal')
         data = solution['sst']
-        solver = self.solver_class(data, weights='invalid')
+        with pytest.raises(ValueError):
+            solver = self.solver_class(data, weights='invalid')
 
-    @raises(ValueError)
     def test_builtin_latitude_weights_with_missing_dimension(self):
         # latitude weights without latitude dimension
         solution = reference_solution('cdms', 'equal')
         data = solution['sst'](latitude=slice(0, 1), squeeze=True)
-        solver = self.solver_class(data, weights='coslat')
+        with pytest.raises(ValueError):
+            solver = self.solver_class(data, weights='coslat')
 
-    @raises(ValueError)
     def test_builtin_area_weights_with_missing_dimension(self):
         # area weights without longitude dimension
         solution = reference_solution('cdms', 'equal')
         data = solution['sst'](longitude=slice(0, 1), squeeze=True)
-        solver = self.solver_class(data, weights='area')
+        with pytest.raises(ValueError):
+            solver = self.solver_class(data, weights='area')
 
-    @raises(ValueError)
     def test_builtin_area_weights_with_non_adjacent_dimensions(self):
         # area weights with latitude and longitude not adjacent in input
         solution = reference_solution('cdms', 'equal')
@@ -319,7 +317,8 @@ class TestConstructorCDMS(EofsTest):
                                     axes=data.getAxisList() + [newdim],
                                     id=data.id)
         data = data.reorder('txzy')
-        solver = self.solver_class(data, weights='area')
+        with pytest.raises(ValueError):
+            solver = self.solver_class(data, weights='area')
 
 
 # ----------------------------------------------------------------------------
@@ -334,62 +333,61 @@ class TestConstructorIris(EofsTest):
         try:
             cls.solver_class = solvers['iris']
         except KeyError:
-            raise SkipTest('library component not available '
-                           'for iris interface')
+            pytest.skip('missing dependencies required to test the '
+                        'iris interface')
 
-    @raises(TypeError)
     def test_wrong_input_type(self):
         # input of the wrong type
         solution = reference_solution('standard', 'equal')
         data = solution['sst']
-        solver = self.solver_class(data)
+        with pytest.raises(TypeError):
+            solver = self.solver_class(data)
 
-    @raises(ValueError)
     def test_input_without_time_dimension(self):
         # no time dimension in the input
         solution = reference_solution('iris', 'equal')
         data = solution['sst'][0]
-        solver = self.solver_class(data)
+        with pytest.raises(ValueError):
+            solver = self.solver_class(data)
 
-    @raises(ValueError)
     def test_input_time_dimension_not_first(self):
         # time not the first dimension in the input
         solution = reference_solution('iris', 'equal')
         data = solution['sst']
         data.transpose((2, 1, 0))
-        solver = self.solver_class(data)
+        with pytest.raises(ValueError):
+            solver = self.solver_class(data)
 
-    @raises(ValueError)
     def test_input_no_spatial_dimensions(self):
         # not enough dimensions in the input
         solution = reference_solution('iris', 'equal')
         data = solution['sst'][:, 0, 0]
-        solver = self.solver_class(data)
+        with pytest.raises(ValueError):
+            solver = self.solver_class(data)
 
-    @raises(ValueError)
     def test_invalid_builtin_weights_value(self):
         # invalid weighting scheme name
         solution = reference_solution('iris', 'equal')
         data = solution['sst']
-        solver = self.solver_class(data, weights='invalid')
+        with pytest.raises(ValueError):
+            solver = self.solver_class(data, weights='invalid')
 
-    @raises(ValueError)
     def test_builtin_latitude_weights_with_missing_dimension(self):
         # latitude weights without latitude dimension
         solution = reference_solution('iris', 'latitude')
         data = solution['sst'][:, 0, :]
         data.remove_coord('latitude')
-        solver = self.solver_class(data, weights='coslat')
+        with pytest.raises(ValueError):
+            solver = self.solver_class(data, weights='coslat')
 
-    @raises(ValueError)
     def test_builtin_area_weights_with_missing_dimension(self):
         # latitude weights without latitude dimension
         solution = reference_solution('iris', 'area')
         data = solution['sst'][:, :, 0]
         data.remove_coord('longitude')
-        solver = self.solver_class(data, weights='area')
+        with pytest.raises(ValueError):
+            solver = self.solver_class(data, weights='area')
 
-    @raises(ValueError)
     def test_multiple_time_dimensions(self):
         # multiple dimensions representing time
         solution = reference_solution('iris', 'equal')
@@ -397,7 +395,8 @@ class TestConstructorIris(EofsTest):
         lon = data.coord('longitude')
         lon.rename('time')
         lon.units = 'days since 1999-01-01 00:00:0.0'
-        solver = self.solver_class(data)
+        with pytest.raises(ValueError):
+            solver = self.solver_class(data)
 
 
 # ----------------------------------------------------------------------------
@@ -412,49 +411,49 @@ class TestConstructorXarray(EofsTest):
         try:
             cls.solver_class = solvers['xarray']
         except KeyError:
-            raise SkipTest('library component not available '
-                           'for iris interface')
+            pytest.skip('missing dependencies required to test the '
+                        'xarray interface')
 
-    @raises(TypeError)
     def test_wrong_input_type(self):
         # input of the wrong type
         solution = reference_solution('standard', 'equal')
         data = solution['sst']
-        solver = self.solver_class(data)
+        with pytest.raises(TypeError):
+            solver = self.solver_class(data)
 
-    @raises(ValueError)
     def test_input_without_time_dimension(self):
         # no time dimension in the input
         solution = reference_solution('xarray', 'equal')
         data = solution['sst'][0]
-        solver = self.solver_class(data)
+        with pytest.raises(ValueError):
+            solver = self.solver_class(data)
 
-    @raises(ValueError)
     def test_input_time_dimension_not_first(self):
         # time not the first dimension in the input
         solution = reference_solution('xarray', 'equal')
         data = solution['sst']
-        data.transpose((2, 1, 0))
-        solver = self.solver_class(data)
+        data = data.transpose('longitude', 'latitude', 'time')
+        with pytest.raises(ValueError):
+            solver = self.solver_class(data)
 
-    @raises(ValueError)
     def test_input_no_spatial_dimensions(self):
         # not enough dimensions in the input
         solution = reference_solution('xarray', 'equal')
         data = solution['sst'][:, 0, 0]
-        solver = self.solver_class(data)
+        with pytest.raises(ValueError):
+            solver = self.solver_class(data)
 
-    @raises(ValueError)
     def test_invalid_builtin_weights_value(self):
         # invalid weighting scheme name
         solution = reference_solution('xarray', 'equal')
         data = solution['sst']
-        solver = self.solver_class(data, weights='invalid')
+        with pytest.raises(ValueError):
+            solver = self.solver_class(data, weights='invalid')
 
-    @raises(ValueError)
     def test_multiple_time_dimensions(self):
         # multiple dimensions representing time
         solution = reference_solution('xarray', 'equal')
         data = solution['sst']
         data.coords['longitude'].attrs['axis'] = 'T'
-        solver = self.solver_class(data)
+        with pytest.raises(ValueError):
+            solver = self.solver_class(data)

--- a/lib/eofs/tests/test_multivariate_error_handling.py
+++ b/lib/eofs/tests/test_multivariate_error_handling.py
@@ -17,13 +17,12 @@
 # along with eofs.  If not, see <http://www.gnu.org/licenses/>.
 from __future__ import (absolute_import, division, print_function)  # noqa
 
-from nose import SkipTest
-from nose.tools import raises
 import numpy as np
 try:
     import cdms2
 except ImportError:
     pass
+import pytest
 
 import eofs.multivariate as multivariate
 from eofs.tests import EofsTest
@@ -53,26 +52,26 @@ class MVErrorHandlersTest(EofsTest):
             cls.solution = reference_multivariate_solution(cls.interface,
                                                            cls.weights)
         except ValueError:
-            raise SkipTest('library component not available '
-                           'for {!s} interface'.format(cls.interface))
+            pytest.skip('missing dependencies required to test '
+                        'the {!s} interface'.format(cls.interface))
         cls.neofs = cls.solution['eigenvalues'].shape[0]
         try:
             cls.solver = solvers[cls.interface](
                 cls.solution['sst'], weights=cls.solution['weights'])
         except KeyError:
-            raise SkipTest('library component not available '
-                           'for {!s} interface'.format(cls.interface))
+            pytest.skip('missing dependencies required to test '
+                        'the {!s} interface'.format(cls.interface))
 
-    @raises(ValueError)
     def test_projectField_wrong_number_fields(self):
-        pcs = self.solver.projectField([self.solution['sst'][0]])
+        with pytest.raises(ValueError):
+            pcs = self.solver.projectField([self.solution['sst'][0]])
 
-    @raises(ValueError)
     def testProjectField_time_dimension_mixture(self):
         sst1, sst2 = self.solution['sst']
         sst1 = sst1[0]
         sst2 = sst2[0:1]
-        pcs = self.solver.projectField([sst1, sst2])
+        with pytest.raises(ValueError):
+            pcs = self.solver.projectField([sst1, sst2])
 
 
 # ----------------------------------------------------------------------------
@@ -92,16 +91,16 @@ class TestErrorHandlersCDMS(MVErrorHandlersTest):
     interface = 'cdms'
     weights = 'equal'
 
-    @raises(TypeError)
     def test_projectField_wrong_input_type(self):
         solution = reference_multivariate_solution('standard', self.weights)
-        pcs = self.solver.projectField(solution['sst'])
+        with pytest.raises(TypeError):
+            pcs = self.solver.projectField(solution['sst'])
 
-    @raises(ValueError)
     def test_projectField_time_dimension_not_first(self):
         sst1, sst2 = self.solution['sst']
         sst1 = sst1.reorder('-t')
-        pcs = self.solver.projectField([sst1, sst2])
+        with pytest.raises(ValueError):
+            pcs = self.solver.projectField([sst1, sst2])
 
 
 # ----------------------------------------------------------------------------
@@ -112,16 +111,16 @@ class TestErrorHandlersIris(MVErrorHandlersTest):
     interface = 'iris'
     weights = 'equal'
 
-    @raises(TypeError)
     def test_projectField_wrong_input_type(self):
         solution = reference_multivariate_solution('standard', self.weights)
-        pcs = self.solver.projectField(solution['sst'])
+        with pytest.raises(TypeError):
+            pcs = self.solver.projectField(solution['sst'])
 
-    @raises(ValueError)
     def test_projectField_time_dimension_not_first(self):
         sst1, sst2 = self.solution['sst']
         sst1.transpose([1, 2, 0])
-        pcs = self.solver.projectField([sst1, sst2])
+        with pytest.raises(ValueError):
+            pcs = self.solver.projectField([sst1, sst2])
 
 
 # ----------------------------------------------------------------------------
@@ -135,27 +134,27 @@ class TestConstructorStandard(EofsTest):
     def setup_class(cls):
         cls.solver_class = solvers['standard']
 
-    @raises(ValueError)
     def test_input_first_dimension_different(self):
         solution = reference_multivariate_solution('standard', 'equal')
         sst1, sst2 = solution['sst']
         sst1 = sst1[0:3]
         sst2 = sst2[0:4]
-        solver = self.solver_class([sst1, sst2])
+        with pytest.raises(ValueError):
+            solver = self.solver_class([sst1, sst2])
 
-    @raises(ValueError)
     def test_wrong_number_weights(self):
         solution = reference_multivariate_solution('standard', 'area')
         weights1, weights2 = solution['weights']
-        solver = self.solver_class(solution['sst'], weights=[weights1])
+        with pytest.raises(ValueError):
+            solver = self.solver_class(solution['sst'], weights=[weights1])
 
-    @raises(ValueError)
     def test_incompatible_weights(self):
         solution = reference_multivariate_solution('standard', 'area')
         weights1, weights2 = solution['weights']
         weights2 = weights2[..., :-1]
-        solver = self.solver_class(solution['sst'],
-                                   weights=[weights1, weights2])
+        with pytest.raises(ValueError):
+            solver = self.solver_class(solution['sst'],
+                                       weights=[weights1, weights2])
 
 
 # ----------------------------------------------------------------------------
@@ -170,33 +169,33 @@ class TestConstructorCDMS(EofsTest):
         try:
             cls.solver_class = solvers['cdms']
         except KeyError:
-            raise SkipTest('library component not available '
-                           'for cdms interface')
+            pytest.skip('missing dependencies required to test '
+                        'the cdms interface')
 
-    @raises(ValueError)
     def test_wrong_number_weights(self):
         solution = reference_multivariate_solution('cdms', 'area')
         weights1, weights2 = solution['weights']
-        solver = self.solver_class(solution['sst'], weights=[weights1])
+        with pytest.raises(ValueError):
+            solver = self.solver_class(solution['sst'], weights=[weights1])
 
-    @raises(TypeError)
     def test_wrong_input_type(self):
         solution = reference_multivariate_solution('standard', 'equal')
-        solver = self.solver_class(solution['sst'])
+        with pytest.raises(TypeError):
+            solver = self.solver_class(solution['sst'])
 
-    @raises(ValueError)
     def test_input_time_dimension_not_first(self):
         solution = reference_multivariate_solution('cdms', 'equal')
         sst1, sst2 = solution['sst']
         sst1 = sst1.reorder('-t')
-        solver = self.solver_class([sst1, sst2])
+        with pytest.raises(ValueError):
+            solver = self.solver_class([sst1, sst2])
 
-    @raises(ValueError)
     def test_input_no_spatial_dimensions(self):
         solution = reference_multivariate_solution('cdms', 'equal')
         sst1, sst2 = solution['sst']
         sst1 = sst1[:, 0, 0]
-        solver = self.solver_class([sst1, sst2])
+        with pytest.raises(ValueError):
+            solver = self.solver_class([sst1, sst2])
 
 
 # ----------------------------------------------------------------------------
@@ -211,30 +210,30 @@ class TestConstructorIris(EofsTest):
         try:
             cls.solver_class = solvers['iris']
         except KeyError:
-            raise SkipTest('library component not available '
-                           'for iris interface')
+            pytest.skip('missing dependencies required to test '
+                        'the iris interface')
 
-    @raises(ValueError)
     def test_wrong_number_weights(self):
         solution = reference_multivariate_solution('iris', 'area')
         weights1, weights2 = solution['weights']
-        solver = self.solver_class(solution['sst'], weights=[weights1])
+        with pytest.raises(ValueError):
+            solver = self.solver_class(solution['sst'], weights=[weights1])
 
-    @raises(TypeError)
     def test_wrong_input_type(self):
         solution = reference_multivariate_solution('standard', 'equal')
-        solver = self.solver_class(solution['sst'])
+        with pytest.raises(TypeError):
+            solver = self.solver_class(solution['sst'])
 
-    @raises(ValueError)
     def test_input_time_dimension_not_first(self):
         solution = reference_multivariate_solution('iris', 'equal')
         sst1, sst2 = solution['sst']
         sst1.transpose([1, 2, 0])
-        solver = self.solver_class([sst1, sst2])
+        with pytest.raises(ValueError):
+            solver = self.solver_class([sst1, sst2])
 
-    @raises(ValueError)
     def test_input_no_spatial_dimensions(self):
         solution = reference_multivariate_solution('iris', 'equal')
         sst1, sst2 = solution['sst']
         sst1 = sst1[:, 0, 0]
-        solver = self.solver_class([sst1, sst2])
+        with pytest.raises(ValueError):
+            solver = self.solver_class([sst1, sst2])

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[tool:pytest]
+addopts = -vrsx
+testpaths = lib


### PR DESCRIPTION
The main switch is from nose to pytest for the test framework. In addition the pep8 library is replaced with pycodestyle.