### PR TITLE
Add support for Dask SVD solver

### DIFF
--- a/lib/eofs/standard.py
+++ b/lib/eofs/standard.py
@@ -162,14 +162,15 @@ class Eof(object):
                 # Use the parallel Dask algorithm
                 dsvd = dask.array.linalg.svd(dataNoMissing)
                 A, Lh, E = (x.compute() for x in dsvd)
+
+                # Trim the arrays (since Dask doesn't support
+                # 'full_matrices=False')
+                A = A[:, :len(Lh)]
+                E = E[:len(Lh), :]
             else:
                 # Basic numpy algorithm
-                A, Lh, E = np.linalg.svd(dataNoMissing)
+                A, Lh, E = np.linalg.svd(dataNoMissing, full_matrices=False)
 
-            # Trim the arrays (since Dask doesn't support
-            # 'full_matrices=False')
-            A = A[:, :len(Lh)]
-            E = E[:len(Lh), :]
         except (np.linalg.LinAlgError, ValueError):
             raise ValueError('error encountered in SVD, check that missing '
                              'values are in the same places at each time and '

--- a/lib/eofs/standard.py
+++ b/lib/eofs/standard.py
@@ -156,6 +156,8 @@ class Eof(object):
         nonMissingIndex = np.where(np.logical_not(np.isnan(self._data[0])))[0]
         # Remove missing values from the design matrix.
         dataNoMissing = self._data[:, nonMissingIndex]
+        if dataNoMissing.size == 0:
+            raise ValueError('all input data is missing')
         # Compute the singular value decomposition of the design matrix.
         try:
             if has_dask and isinstance(dataNoMissing, dask.array.Array):

--- a/lib/eofs/tests/test_solution.py
+++ b/lib/eofs/tests/test_solution.py
@@ -285,7 +285,7 @@ class TestStandardDask(StandardSolutionTest):
     @classmethod
     def modify_solution(cls):
         # Skip this class if dask not available
-        pytest.importorskip('dask.array')
+        pytest.importorskip('dask.array', minversion='1.0')
         import dask
 
         sst = cls.solution['sst']

--- a/lib/eofs/tests/test_solution.py
+++ b/lib/eofs/tests/test_solution.py
@@ -285,7 +285,7 @@ class TestStandardDask(StandardSolutionTest):
     @classmethod
     def modify_solution(cls):
         # Skip this class if dask not available
-        pytest.importorskip('dask.array', minversion='1.0')
+        pytest.importorskip('dask.array')
         import dask
 
         sst = cls.solution['sst']

--- a/lib/eofs/tests/test_solution.py
+++ b/lib/eofs/tests/test_solution.py
@@ -284,7 +284,10 @@ class TestStandardDask(StandardSolutionTest):
 
     @classmethod
     def modify_solution(cls):
+        # Skip this class if dask not available
+        pytest.importorskip('dask.array')
         import dask
+
         sst = cls.solution['sst']
         da = dask.array.from_array(sst, chunks=(1, -1, -1))
         dm = dask.array.from_array(sst.mask, chunks=(1, -1, -1))
@@ -327,6 +330,9 @@ class TestXarrayDask(XarraySolutionTest):
 
     @classmethod
     def modify_solution(cls):
+        # Skip this class if dask not available
+        pytest.importorskip('dask.array')
+
         cls.solution['sst'] = cls.solution['sst'].chunk({'time': 1})
 
     def test_source_is_dask(self):

--- a/lib/eofs/xarray.py
+++ b/lib/eofs/xarray.py
@@ -127,7 +127,7 @@ class Eof(object):
         except AttributeError:
             pass
         # Construct the EOF solver.
-        self._solver = standard.Eof(array.values,
+        self._solver = standard.Eof(array.data,
                                     weights=wtarray,
                                     center=center,
                                     ddof=ddof)


### PR DESCRIPTION
The Dask array library includes a parallel SVD solver. Use this to compute the EOF, provided the input data is a Dask array (e.g. from using `xarray.open_dataset(..., chunks={'time': 10})`)

Dask arrays are only used for the input to the EOF calculation. Because of the way that masking works the output from the SVD solver is converted into normal Numpy arrays. There should still be some benefit from the parallel SVD algorithm that Dask uses, though I've not measured performance.

Both the standard and Xarray solvers are supported. Iris can in theory use Dask, but I couldn't see how to set up test data for it.