### PR TITLE
Address numpy DeprecationWarnings

### DIFF
--- a/lib/eofs/standard.py
+++ b/lib/eofs/standard.py
@@ -16,12 +16,19 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with eofs.  If not, see <http://www.gnu.org/licenses/>.
-from __future__ import (absolute_import, division, print_function)  # noqa
+from __future__ import absolute_import, division, print_function  # noqa
+
 import collections.abc
 import warnings
 
 import numpy as np
 import numpy.ma as ma
+from packaging.version import Version
+
+if Version(np.__version__) < Version('1.25.0'):
+    from numpy import product as prod
+else:
+    from numpy import prod
 
 try:
     import dask.array
@@ -121,7 +128,7 @@ class Eof(object):
         # Store information about the shape/size of the input data.
         self._records = self._data.shape[0]
         self._originalshape = self._data.shape[1:]
-        channels = np.product(self._originalshape)
+        channels = prod(self._originalshape)
         # Weight the data set according to weighting argument.
         if weights is not None:
             try:
@@ -738,7 +745,7 @@ class Eof(object):
         if eof_ndim > input_ndim:
             field = field.reshape((1,) + field.shape)
         records = field.shape[0]
-        channels = np.product(field.shape[1:])
+        channels = prod(field.shape[1:])
         field_flat = field.reshape([records, channels])
         # Locate the non-missing values and isolate them.
         if not self._valid_nan(field_flat):

--- a/lib/eofs/standard.py
+++ b/lib/eofs/standard.py
@@ -119,7 +119,7 @@ class Eof(object):
             raise ValueError('the input data set must be '
                              'at least two dimensional')
         self._data = dataset.copy()
-        # Check if the input is a masked array. If so fill it with NaN.
+        # Check if the input is a masked array. If so fill it with nan.
         try:
             self._data = self._data.filled(fill_value=np.nan)
             self._filled = True
@@ -201,9 +201,9 @@ class Eof(object):
         # as they exist in the input maps. Create an array of not-a-numbers
         # and then introduce data values where required. We have to use the
         # astype method to ensure the eigenvectors are the same type as the
-        # input dataset since multiplication by np.NaN will promote to 64-bit.
+        # input dataset since multiplication by np.nan will promote to 64-bit.
         self._flatE = np.ones([self.neofs, channels],
-                              dtype=self._data.dtype) * np.NaN
+                              dtype=self._data.dtype) * np.nan
         self._flatE = self._flatE.astype(self._data.dtype)
         self._flatE[:, nonMissingIndex] = E
         # Remove the scaling on the principal component time-series that is
@@ -736,7 +736,7 @@ class Eof(object):
             wts = self.getWeights()
             if wts is not None:
                 field = field * wts
-        # Fill missing values with NaN if this is a masked array.
+        # Fill missing values with nan if this is a masked array.
         try:
             field = field.filled(fill_value=np.nan)
         except AttributeError:

--- a/lib/eofs/tools/standard.py
+++ b/lib/eofs/tools/standard.py
@@ -19,6 +19,12 @@ from __future__ import (absolute_import, division, print_function)  # noqa
 
 import numpy as np
 import numpy.ma as ma
+from packaging.version import Version
+
+if Version(np.__version__) < Version('1.25.0'):
+    from numpy import product as prod
+else:
+    from numpy import prod
 
 
 def _check_flat_center(pcs, field):
@@ -46,7 +52,7 @@ def _check_flat_center(pcs, field):
     else:
         # Record the shape of the field and the number of spatial elements.
         originalshape = field.shape[1:]
-        channels = np.product(originalshape)
+        channels = prod(originalshape)
     # Record the number of PCs.
     if len(pcs.shape) == 1:
         npcs = 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dynamic = [
 ]
 dependencies = [
   "numpy",
+  "packaging",
 ]
 [project.optional-dependencies]
 extras = [


### PR DESCRIPTION
Hi there,

I've been working to reduce warnings in a downstream project and figured I could send a PR your way to address some messages coming from here.

### Changes
* Added the `packaging` library (provides a version-parsing replacement for the deprecated `distutils`, endorsed by PyPA)
* Added a backwards-compatible `numpy.{prod|product}`, which can be removed when `eofs` drops Python3.8 support.
* Replaced deprecated `np.NaN` artifacts with `np.nan`.

All the best!