### PR TITLE
DOC: update external links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 eofs - EOF analysis in Python
 =============================
 
-[![DOI (paper)](https://img.shields.io/badge/DOI%20%28paper%29-10.5334%2Fjors.122-blue.svg)](http://doi.org/10.5334/jors.122) [![DOI (latest release)](https://zenodo.org/badge/20448/ajdawson/eofs.svg)](https://zenodo.org/badge/latestdoi/20448/ajdawson/eofs)
+[![DOI (paper)](https://img.shields.io/badge/DOI%20%28paper%29-10.5334%2Fjors.122-blue.svg)](https://doi.org/10.5334/jors.122) [![DOI (latest release)](https://zenodo.org/badge/20448/ajdawson/eofs.svg)](https://zenodo.org/badge/latestdoi/20448/ajdawson/eofs)
 
 
 Overview
@@ -22,28 +22,28 @@ Requirements
 ------------
 
 eofs only requires the NumPy package (and setuptools to install).
-In order to use the meta-data preserving interfaces one (or both) of [iris](http://scitools.org.uk/iris) or [xarray](http://xarray.pydata.org) is needed.
+In order to use the meta-data preserving interfaces one (or both) of [iris](https://scitools-iris.readthedocs.io) or [xarray](https://docs.xarray.dev/en/stable) is needed.
 
 
 Documentation
 -------------
 
-Documentation is available [online](http://ajdawson.github.io/eofs).
+Documentation is available [online](https://ajdawson.github.io/eofs).
 The package docstrings are also very complete and can be used as a source of reference when working interactively.
 
 
 Citation
 --------
 
-If you use eofs in published research, please cite it by referencing the [peer-reviewed paper](http://doi.org/10.5334/jors.122).
-You can additionally cite the [Zenodo DOI](http://dx.doi.org/10.5281/zenodo.46871) if you need to cite a particular version (but please also cite the paper, it helps me justify my time working on this and similar projects).
+If you use eofs in published research, please cite it by referencing the [peer-reviewed paper](https://doi.org/10.5334/jors.122).
+You can additionally cite the [Zenodo DOI](https://dx.doi.org/10.5281/zenodo.46871) if you need to cite a particular version (but please also cite the paper, it helps me justify my time working on this and similar projects).
 
 
 Installation
 ------------
 
 eofs works on Python 3 on Linux, Windows or MacOS.
-The easiest way to install eofs is by using [conda](http://conda.pydata.org/docs/) or pip:
+The easiest way to install eofs is by using [conda](https://docs.conda.io/en/latest/) or pip:
 
     conda install -c conda-forge eofs
 

--- a/doc/_themes/sphinx13/layout.html
+++ b/doc/_themes/sphinx13/layout.html
@@ -16,7 +16,7 @@
 
 
 {% block extrahead %}
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans:300,400,700'
+    <link href='https://fonts.googleapis.com/css?family=Open+Sans:300,400,700'
           rel='stylesheet' type='text/css' />
     {{ super() }}
     {%- if not embedded %}

--- a/doc/devguide/testing.rst
+++ b/doc/devguide/testing.rst
@@ -40,6 +40,6 @@ This will run the tests on the version of `eofs` you just installed.
 
 .. _pytest: https://docs.pytest.org/en/latest/
 
-.. _iris: http://scitools.org.uk/iris
+.. _iris: https://scitools-iris.readthedocs.io
 
-.. _xarray: http://xarray.pydata.org
+.. _xarray: https://docs.xarray.dev/en/stable

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -102,9 +102,9 @@ If you would like to contribute code or documentation please see the :doc:`devgu
 
 .. _dask: https://www.dask.org/
 
-.. _iris: http://scitools.org.uk/iris
+.. _iris: https://scitools-iris.readthedocs.io
 
-.. _xarray: http://xarray.pydata.org
+.. _xarray: https://docs.xarray.dev/en/stable
 
 .. _numpy: https://numpy.org/
 

--- a/examples/iris/hgt_example.py
+++ b/examples/iris/hgt_example.py
@@ -6,9 +6,9 @@ This example uses the metadata-retaining iris interface.
 
 Additional requirements for this example:
 
-    * iris (http://scitools.org.uk/iris/)
-    * matplotlib (http://matplotlib.org/)
-    * cartopy (http://scitools.org.uk/cartopy/)
+    * iris (https://scitools-iris.readthedocs.io/)
+    * matplotlib (https://matplotlib.org/)
+    * cartopy (https://cartopy.readthedocs.io/)
 
 """
 import warnings

--- a/examples/iris/sst_example.py
+++ b/examples/iris/sst_example.py
@@ -10,9 +10,9 @@ This example uses the metadata-retaining iris interface.
 
 Additional requirements for this example:
 
-    * iris (http://scitools.org.uk/iris/)
-    * matplotlib (http://matplotlib.org/)
-    * cartopy (http://scitools.org.uk/cartopy/)
+    * iris (https://scitools-iris.readthedocs.io/)
+    * matplotlib (https://matplotlib.org/)
+    * cartopy (https://cartopy.readthedocs.io/)
 
 """
 import cartopy.crs as ccrs

--- a/examples/standard/hgt_example.py
+++ b/examples/standard/hgt_example.py
@@ -6,9 +6,9 @@ This example uses the plain numpy interface.
 
 Additional requirements for this example:
 
-    * netCDF4 (http://unidata.github.io/netcdf4-python/)
-    * matplotlib (http://matplotlib.org/)
-    * cartopy (http://scitools.org.uk/cartopy/)
+    * netCDF4 (https://unidata.github.io/netcdf4-python/)
+    * matplotlib (https://matplotlib.org/)
+    * cartopy (https://cartopy.readthedocs.io/)
 
 """
 import cartopy.crs as ccrs

--- a/examples/standard/sst_example.py
+++ b/examples/standard/sst_example.py
@@ -10,9 +10,9 @@ This example uses the plain numpy interface.
 
 Additional requirements for this example:
 
-    * netCDF4 (http://unidata.github.io/netcdf4-python/)
-    * matplotlib (http://matplotlib.org/)
-    * cartopy (http://scitools.org.uk/cartopy/)
+    * netCDF4 (https://unidata.github.io/netcdf4-python/)
+    * matplotlib (https://matplotlib.org/)
+    * cartopy (https://cartopy.readthedocs.io/)
 
 """
 import cartopy.crs as ccrs

--- a/examples/xarray/hgt_example.py
+++ b/examples/xarray/hgt_example.py
@@ -6,9 +6,9 @@ This example uses the metadata-retaining xarray interface.
 
 Additional requirements for this example:
 
-    * xarray (http://xarray.pydata.org)
-    * matplotlib (http://matplotlib.org/)
-    * cartopy (http://scitools.org.uk/cartopy/)
+    * xarray (https://docs.xarray.dev/en/stable)
+    * matplotlib (https://matplotlib.org/)
+    * cartopy (https://cartopy.readthedocs.io/)
 
 """
 import cartopy.crs as ccrs

--- a/examples/xarray/sst_example.py
+++ b/examples/xarray/sst_example.py
@@ -10,9 +10,9 @@ This example uses the metadata-retaining xarray interface.
 
 Additional requirements for this example:
 
-    * xarray (http://xarray.pydata.org)
-    * matplotlib (http://matplotlib.org/)
-    * cartopy (http://scitools.org.uk/cartopy/)
+    * xarray (https://docs.xarray.dev/en/stable)
+    * matplotlib (https://matplotlib.org/)
+    * cartopy (https://cartopy.readthedocs.io/)
 
 """
 import cartopy.crs as ccrs


### PR DESCRIPTION
Hi @ajdawson,

I created this branch to update the Cartopy and Iris links, since these are both now hosted on ReadTheDocs.  The existing links work for now because we have redirects in place, but there is talk of retiring the scitools.org.uk site at some point.

I figured it wouldn't hurt to also update `http` to `https` (except where it appears in license information - I don't want to touch that!)  While checking the updated links I also noticed that the xarray and conda links were redirecting, so updated those to the new location.